### PR TITLE
fix cloudbuild cluster name again

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
 - name: "gcr.io/cloud-builders/docker"
   args: 
   - run
+  - --network=cloudbuild
   - --filename=gke.yaml
   - --image=gcr.io/$PROJECT_ID/gcpdevops
   - --location=us-central1-c


### PR DESCRIPTION
fix cloudbuild cluster name again just added --network, and hope it fixes that sh*t error